### PR TITLE
fix the licence classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     license="GNU General Public License v3.0",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License v3.0",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',


### PR DESCRIPTION
I used the wrong classifier for the licence. Valid classifiers can be found here https://pypi.org/classifiers/. Updated in the package as well.