### PR TITLE
fix version to match in PYPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-# 1.3.1
+# 1.3.2
 - Fixed header contamination in download file content-type
+
+## 1.3.1
+- Fix processrun.py
 
 # 1.3.0
 - Updated version and usage of the filesplit package

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="solvexia_sdk", 
-    version="1.3.1",
+    version="1.3.2",
     author="Solvexia Pty Ltd",
     author_email="support@solvexia.com",
     description="A development kit written in Python to access and work with Solvexia resources",


### PR DESCRIPTION
PyPi version is already on 1.3.1 so next should be 1.3.2. Change logs and tag were missing. Added the change logs but tag was too late. I already tagged my changed to 1.3.1. So after this PR is merged. I will tag again with 1.3.2 then release to PyPi